### PR TITLE
removed address from book-reference

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -17,8 +17,7 @@ CREATE TABLE IF NOT EXISTS book (
     author TEXT, 
     title TEXT, 
     year INTEGER, 
-    publisher TEXT,
-    address TEXT
+    publisher TEXT
 );
 
 CREATE TABLE IF NOT EXISTS article (

--- a/sql/seed.sql
+++ b/sql/seed.sql
@@ -1,2 +1,2 @@
-INSERT INTO book (user_key, author, title, year, publisher) VALUES ('AB1', 'Tolkien, J.R.R.', 'The Lord of the Rings', 1954, 'Allen & Unwin');
-INSERT INTO book (user_key, author, title, year, publisher) VALUES ('BC2', 'Tolkien, J.R.R.', 'The Hobbit', 1937, 'George Allen & Unwin');
+INSERT INTO book (cite_key, author, title, year, publisher) VALUES ('AB1', 'Tolkien, J.R.R.', 'The Lord of the Rings', 1954, 'Allen & Unwin');
+INSERT INTO book (cite_key, author, title, year, publisher) VALUES ('BC2', 'Tolkien, J.R.R.', 'The Hobbit', 1937, 'George Allen & Unwin');

--- a/src/db/book.py
+++ b/src/db/book.py
@@ -25,15 +25,14 @@ def insert_one(ref):
     """
     Inserts one book into database
     """
-    sql = text("INSERT INTO book (cite_key, author, title, year, publisher, address)"
-               " VALUES (:key, :author, :title, :year, :publisher, :address)")
+    sql = text("INSERT INTO book (cite_key, author, title, year, publisher)"
+               " VALUES (:key, :author, :title, :year, :publisher)")
     parsed_reference = {
         "key": ref["key"],
         "author": ref["author"],
         "title": ref["title"],
         "year": ref["year"],
-        "publisher": ref["publisher"],
-        "address": ref["address"]
+        "publisher": ref["publisher"]
     }
     db.session.execute(sql, parsed_reference)
     db.session.commit()
@@ -48,8 +47,7 @@ def parse_fetchall(rows):
             "author": rows[2],
             "title": rows[3],
             "year": rows[4],
-            "publisher": rows[5],
-            "address": rows[6],
+            "publisher": rows[5]
             }
 
     return fields

--- a/src/references/book.py
+++ b/src/references/book.py
@@ -21,7 +21,6 @@ class Book(Reference):
                 "year":fields['year']
                 })
         self._publisher = fields['publisher']
-        self._address = fields['address']
 
     @property
     def publisher(self):
@@ -37,20 +36,6 @@ class Book(Reference):
         """
         self._publisher = publisher
 
-    @property
-    def address(self):
-        """
-        Return address
-        """
-        return self._address
-
-    @address.setter
-    def address(self, address):
-        """
-        Sets address
-        """
-        self._address = address
-
     def bibtex_str(self) -> str:
         # \u007b = {
         # \u007d = }
@@ -59,6 +44,5 @@ class Book(Reference):
     author = {self.author}
     year = {self.year}
     publisher = {self.publisher}
-    address = {self.address}
 \u007d"""
         return string

--- a/tests/book_test.py
+++ b/tests/book_test.py
@@ -39,21 +39,12 @@ class TestBook(unittest.TestCase):
         self.reference.publisher = "publisher2"
         self.assertEqual(self.reference.publisher, "publisher2")
 
-    def test_address_takes_constructor_value(self):
-        self.reference.address = "address"
-        self.assertEqual(self.reference.address, "address")
-
-    def test_set_address_changes_address(self):
-        self.reference.address = "address2"
-        self.assertEqual(self.reference.address, "address2")
-
     def test_bibtex_str(self):
         example_str = """@book{Someuniquekey
     title = idk
     author = mk
     year = 2001
     publisher = publisher
-    address = address
 }"""
         bibtex_str = self.reference.bibtex_str()
         self.assertEqual(bibtex_str, example_str)

--- a/tests/database_tests/book_test.py
+++ b/tests/database_tests/book_test.py
@@ -21,8 +21,7 @@ class BookDatabaseTest(TestCase):
             "author": "Me",
             "title": "My best book", 
             "year": 2023,
-            "publisher": "Edelleen minä", 
-            "address": "Manaattikuja 69"
+            "publisher": "Edelleen minä"
         }
 
         with app.app_context():
@@ -40,7 +39,6 @@ class BookDatabaseTest(TestCase):
             self.assertEqual(result[0].title, "My best book")
             self.assertEqual(result[0].year, 2023)
             self.assertEqual(result[0].publisher, "Edelleen minä")
-            self.assertEqual(result[0].address, "Manaattikuja 69")
         else:
             raise AssertionError("No result from database")
 


### PR DESCRIPTION
Selvitin `address = None` kentän bibtex tiedoston luonnista. Kentän arvo johtui `seed.sql` tiedostossa olevista alustavista viitteistä. Poistin koko addres kentän book-viitteistä.